### PR TITLE
fix for rapidjson, where filestream was split to buffered read/write …

### DIFF
--- a/src/cl/SoDATools/test-selection-statistics/CDataManager.cpp
+++ b/src/cl/SoDATools/test-selection-statistics/CDataManager.cpp
@@ -23,7 +23,7 @@
 #include "util/CSelectionStatistics.h"
 #include "CDataManager.h"
 #include "rapidjson/prettywriter.h"
-#include "rapidjson/filestream.h"
+#include "rapidjson/filewritestream.h"
 
 using namespace std;
 
@@ -66,8 +66,9 @@ void CDataManager::calcStatistics()
         rapidjson::Document res;
         res.SetObject();
         stats.calcCoverageRelatedStatistics(res);
-        rapidjson::FileStream f(stdout);
-        rapidjson::PrettyWriter<rapidjson::FileStream> writer(f);
+        char writeBuffer[65535];
+        rapidjson::FileWriteStream f(stdout, writeBuffer, sizeof(writeBuffer));
+        rapidjson::PrettyWriter<rapidjson::FileWriteStream> writer(f);
         res.Accept(writer);
     }
     /*if (m_testMask & tmFails) {
@@ -80,8 +81,9 @@ void CDataManager::calcStatistics()
         rapidjson::Document res;
         res.SetObject();
         stats.calcCovResultsSummary(res);
-        rapidjson::FileStream f(stdout);
-        rapidjson::PrettyWriter<rapidjson::FileStream> writer(f);
+        char writeBuffer[65535];
+        rapidjson::FileWriteStream f(stdout, writeBuffer, sizeof(writeBuffer));
+        rapidjson::PrettyWriter<rapidjson::FileWriteStream> writer(f);
         res.Accept(writer);
     }
 }


### PR DESCRIPTION
…streams.

Building the tool cl/sodaTools/test-selection-statistics from master branch (e.g cmake followed by make) failed for me because the rapidjson version checked out by cmake from the SVN repo contains a change where the filestream class had been removed.

 I replaced the obsolete rapidjson call but did not test the change beyond successfully building it.
